### PR TITLE
Refactor bills page into reusable components

### DIFF
--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -3,49 +3,15 @@
 
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
-import useSWR from 'swr';
 import { useState } from 'react';
-import {formatDateSafe} from '@/src/utils';
-
-interface Expense {
-  id: number;
-  vendor: string | null;
-  description: string;
-  total: number;
-  currency: string;
-  expenseType: string;
-  category?: string;
-  date: string;
-  source: {
-    type: string;
-    description: string | null;
-    receivedAt: string;
-  };
-  invoiceDetails: {
-    product: string;
-    quantity: number;
-    unitPrice: number;
-  }[];
-}
-
-const fetcher = (url: string) => fetch(url).then(res => res.json());
-
-const CATEGORIES = [
-  'FOOD',
-  'TRANSPORT',
-  'MEDICAL',
-  'SERVICES',
-  'SUBSCRIPTIONS',
-  'INSTALLMENTS',
-  'ENTERTAINMENT',
-  'HOUSEHOLD',
-  'EDUCATION',
-  'OTHER',
-];
+import BillList from '@/components/bills/BillList';
+import BillsFilters from '@/components/bills/BillsFilters';
+import FloatingButton from '@/components/ui/FloatingButton';
+import useBills from '@/src/hooks/useBills';
 
 export default function BillsPage() {
   const router = useRouter();
-  const { data, error, isLoading, mutate } = useSWR('/api/expenses', fetcher);
+  const { bills, error, isLoading, deleteBill } = useBills();
   const [categoryFilter, setCategoryFilter] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [startDate, setStartDate] = useState('');
@@ -58,19 +24,15 @@ export default function BillsPage() {
   const handleDelete = async (id: number) => {
     if (!confirm('¿Está seguro que desea eliminar esta factura?')) return;
 
-    const res = await fetch(`/api/expenses/${id}`, {
-      method: 'DELETE',
-    });
-
-    if (res.ok) {
+    try {
+      await deleteBill(id);
       toast.success('Factura eliminada correctamente');
-      mutate();
-    } else {
+    } catch {
       toast.error('Ocurrió un error al eliminar la factura.');
     }
   };
 
-  const filteredData = data?.data?.filter((gasto: Expense) => {
+  const filteredData = bills.filter((gasto) => {
     const matchCategory = categoryFilter ? gasto.category === categoryFilter : true;
     const matchSearch = searchTerm
       ? gasto.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -85,143 +47,25 @@ export default function BillsPage() {
     <div className="relative min-h-screen p-6 max-w-5xl mx-auto">
       <h1 className="text-3xl font-bold text-blue-700 mb-6">📄 Facturas registradas</h1>
 
-      <div className="mb-4 flex flex-wrap gap-4 items-end">
-        <div>
-          <label className="mr-2 font-medium">Filtrar por categoría:</label>
-          <select
-            value={categoryFilter}
-            onChange={(e) => setCategoryFilter(e.target.value)}
-            className="border border-gray-300 px-3 py-2 rounded-md"
-          >
-            <option value="">Todas</option>
-            {CATEGORIES.map((cat) => (
-              <option key={cat} value={cat}>
-                {cat.charAt(0).toUpperCase() + cat.slice(1).toLowerCase()}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label className="mr-2 font-medium">Buscar:</label>
-          <input
-            type="text"
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="border border-gray-300 px-3 py-2 rounded-md"
-            placeholder="Proveedor o descripción"
-          />
-        </div>
-
-        <div>
-          <label className="mr-2 font-medium">Desde:</label>
-          <input
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-            className="border border-gray-300 px-3 py-2 rounded-md"
-          />
-        </div>
-
-        <div>
-          <label className="mr-2 font-medium">Hasta:</label>
-          <input
-            type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
-            className="border border-gray-300 px-3 py-2 rounded-md"
-          />
-        </div>
-      </div>
+      <BillsFilters
+        category={categoryFilter}
+        onCategoryChange={setCategoryFilter}
+        search={searchTerm}
+        onSearchChange={setSearchTerm}
+        startDate={startDate}
+        onStartDateChange={setStartDate}
+        endDate={endDate}
+        onEndDateChange={setEndDate}
+      />
 
       {isLoading && <p className="text-gray-600">Cargando facturas...</p>}
       {error && <p className="text-red-600">❌ Error al cargar las facturas.</p>}
 
       {!isLoading && !error && (
-        <>
-          {filteredData?.length === 0 ? (
-            <p className="text-gray-500 text-center">No hay facturas registradas aún.</p>
-          ) : (
-            <ul className="space-y-6">
-              {filteredData.map((gasto: Expense) => (
-                <li
-                  key={gasto.id}
-                  className="border border-gray-200 rounded-xl p-5 shadow-sm bg-white hover:shadow-md transition"
-                >
-                  <div className="flex justify-between items-center mb-2">
-                    <h2 className="text-lg font-semibold text-gray-800">
-                      {gasto.vendor || 'Proveedor desconocido'}
-                    </h2>
-                    <span className="text-sm text-gray-500">
-                      {formatDateSafe(gasto.date)}
-                    </span>
-                  </div>
-
-                  <p className="text-gray-700">{gasto.description}</p>
-
-                  {gasto.category && (
-                    <p className="text-sm text-blue-600 font-medium mt-1">
-                      Categoría: {gasto.category}
-                    </p>
-                  )}
-
-                  <p className="text-xl font-bold text-green-600 mt-3">
-                    {gasto.total.toLocaleString('es-CR', {
-                      style: 'currency',
-                      currency: gasto.currency,
-                    })}
-                  </p>
-
-                  <p className="text-sm text-gray-500 mt-1">
-                    Origen: <span className="italic">{gasto.source.type}</span>
-                    {gasto.source.description && ` (${gasto.source.description})`}
-                  </p>
-
-                  {gasto.expenseType === 'invoice' && gasto.invoiceDetails.length > 0 && (
-                    <div className="mt-4 bg-gray-50 p-3 rounded-md border">
-                      <p className="font-semibold mb-1 text-sm text-gray-700">Detalles de factura:</p>
-                      <ul className="list-disc pl-5 text-sm text-gray-600 space-y-1">
-                        {gasto.invoiceDetails.map((item, idx) => (
-                          <li key={idx}>
-                            {item.quantity} x {item.product} @{' '}
-                            {item.unitPrice.toLocaleString('es-CR', {
-                              style: 'currency',
-                              currency: gasto.currency,
-                            })}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-
-                  <div className="mt-4 flex gap-3">
-                    <button
-                      onClick={() => handleEdit(gasto.id)}
-                      className="px-4 py-2 bg-yellow-500 text-white rounded-md text-sm hover:bg-yellow-600 transition"
-                    >
-                      Modificar
-                    </button>
-                    <button
-                      onClick={() => handleDelete(gasto.id)}
-                      className="px-4 py-2 bg-red-500 text-white rounded-md text-sm hover:bg-red-600 transition"
-                    >
-                      Eliminar
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </>
+        <BillList bills={filteredData} onEdit={handleEdit} onDelete={handleDelete} />
       )}
 
-      {/* Botón flotante */}
-      <button
-        onClick={() => router.push('/new-bill')}
-        className="fixed bottom-8 right-8 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg transition text-sm font-semibold"
-      >
-        ➕ Agregar Gasto
-      </button>
+      <FloatingButton onClick={() => router.push('/new-bill')}>➕ Agregar Gasto</FloatingButton>
     </div>
   );
 }

--- a/components/bills/BillItem.tsx
+++ b/components/bills/BillItem.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { Expense } from '@/src/types/expense';
+import { formatDateSafe } from '@/src/utils';
+
+interface BillItemProps {
+  bill: Expense;
+  onEdit: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+export default function BillItem({ bill, onEdit, onDelete }: BillItemProps) {
+  return (
+    <li className="border border-gray-200 rounded-xl p-5 shadow-sm bg-white hover:shadow-md transition">
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="text-lg font-semibold text-gray-800">
+          {bill.vendor || 'Proveedor desconocido'}
+        </h2>
+        <span className="text-sm text-gray-500">{formatDateSafe(bill.date)}</span>
+      </div>
+
+      <p className="text-gray-700">{bill.description}</p>
+
+      {bill.category && (
+        <p className="text-sm text-blue-600 font-medium mt-1">Categoría: {bill.category}</p>
+      )}
+
+      <p className="text-xl font-bold text-green-600 mt-3">
+        {bill.total.toLocaleString('es-CR', { style: 'currency', currency: bill.currency })}
+      </p>
+
+      <p className="text-sm text-gray-500 mt-1">
+        Origen: <span className="italic">{bill.source.type}</span>
+        {bill.source.description && ` (${bill.source.description})`}
+      </p>
+
+      {bill.expenseType === 'invoice' && bill.invoiceDetails.length > 0 && (
+        <div className="mt-4 bg-gray-50 p-3 rounded-md border">
+          <p className="font-semibold mb-1 text-sm text-gray-700">Detalles de factura:</p>
+          <ul className="list-disc pl-5 text-sm text-gray-600 space-y-1">
+            {bill.invoiceDetails.map((item, idx) => (
+              <li key={idx}>
+                {item.quantity} x {item.product} @{' '}
+                {item.unitPrice.toLocaleString('es-CR', { style: 'currency', currency: bill.currency })}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-4 flex gap-3">
+        <button
+          onClick={() => onEdit(bill.id)}
+          className="px-4 py-2 bg-yellow-500 text-white rounded-md text-sm hover:bg-yellow-600 transition"
+        >
+          Modificar
+        </button>
+        <button
+          onClick={() => onDelete(bill.id)}
+          className="px-4 py-2 bg-red-500 text-white rounded-md text-sm hover:bg-red-600 transition"
+        >
+          Eliminar
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/components/bills/BillList.tsx
+++ b/components/bills/BillList.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { Expense } from '@/src/types/expense';
+import BillItem from './BillItem';
+
+interface BillListProps {
+  bills: Expense[];
+  onEdit: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+export default function BillList({ bills, onEdit, onDelete }: BillListProps) {
+  if (bills.length === 0) {
+    return <p className="text-gray-500 text-center">No hay facturas registradas aún.</p>;
+  }
+
+  return (
+    <ul className="space-y-6">
+      {bills.map((bill) => (
+        <BillItem key={bill.id} bill={bill} onEdit={onEdit} onDelete={onDelete} />
+      ))}
+    </ul>
+  );
+}

--- a/components/bills/BillsFilters.tsx
+++ b/components/bills/BillsFilters.tsx
@@ -1,0 +1,88 @@
+'use client';
+import React from 'react';
+
+const CATEGORIES = [
+  'FOOD',
+  'TRANSPORT',
+  'MEDICAL',
+  'SERVICES',
+  'SUBSCRIPTIONS',
+  'INSTALLMENTS',
+  'ENTERTAINMENT',
+  'HOUSEHOLD',
+  'EDUCATION',
+  'OTHER',
+];
+
+interface BillsFiltersProps {
+  category: string;
+  onCategoryChange: (value: string) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+  startDate: string;
+  onStartDateChange: (value: string) => void;
+  endDate: string;
+  onEndDateChange: (value: string) => void;
+}
+
+export default function BillsFilters({
+  category,
+  onCategoryChange,
+  search,
+  onSearchChange,
+  startDate,
+  onStartDateChange,
+  endDate,
+  onEndDateChange,
+}: BillsFiltersProps) {
+  return (
+    <div className="mb-4 flex flex-wrap gap-4 items-end">
+      <div>
+        <label className="mr-2 font-medium">Filtrar por categoría:</label>
+        <select
+          value={category}
+          onChange={(e) => onCategoryChange(e.target.value)}
+          className="border border-gray-300 px-3 py-2 rounded-md"
+        >
+          <option value="">Todas</option>
+          {CATEGORIES.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat.charAt(0).toUpperCase() + cat.slice(1).toLowerCase()}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="mr-2 font-medium">Buscar:</label>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="border border-gray-300 px-3 py-2 rounded-md"
+          placeholder="Proveedor o descripción"
+        />
+      </div>
+
+      <div>
+        <label className="mr-2 font-medium">Desde:</label>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => onStartDateChange(e.target.value)}
+          className="border border-gray-300 px-3 py-2 rounded-md"
+        />
+      </div>
+
+      <div>
+        <label className="mr-2 font-medium">Hasta:</label>
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => onEndDateChange(e.target.value)}
+          className="border border-gray-300 px-3 py-2 rounded-md"
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/ui/FloatingButton.tsx
+++ b/components/ui/FloatingButton.tsx
@@ -1,0 +1,18 @@
+'use client';
+import React from 'react';
+
+interface FloatingButtonProps {
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+export default function FloatingButton({ onClick, children }: FloatingButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-8 right-8 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg transition text-sm font-semibold"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/hooks/useBills.ts
+++ b/src/hooks/useBills.ts
@@ -1,0 +1,22 @@
+import useSWR from 'swr';
+import { Expense } from '@/src/types/expense';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function useBills() {
+  const { data, error, isLoading, mutate } = useSWR('/api/expenses', fetcher);
+
+  const deleteBill = async (id: number) => {
+    const res = await fetch(`/api/expenses/${id}`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('Failed to delete bill');
+    mutate();
+  };
+
+  return {
+    bills: (data?.data as Expense[]) || [],
+    error,
+    isLoading,
+    deleteBill,
+    mutate,
+  };
+}

--- a/src/types/expense.ts
+++ b/src/types/expense.ts
@@ -1,0 +1,25 @@
+export interface InvoiceDetail {
+  product: string;
+  quantity: number;
+  unitPrice: number;
+}
+
+export interface Source {
+  type: string;
+  description: string | null;
+  receivedAt: string;
+  fileUrl?: string | null;
+}
+
+export interface Expense {
+  id: number;
+  vendor: string | null;
+  description: string;
+  total: number;
+  currency: string;
+  expenseType?: string;
+  category?: string | null;
+  date: string;
+  source: Source;
+  invoiceDetails: InvoiceDetail[];
+}


### PR DESCRIPTION
## Summary
- extract BillsFilters, BillList and BillItem components
- add FloatingButton component
- create reusable `useBills` hook and Expense types
- refactor `app/bills/page.tsx` to use new hook and components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685899e092c48321a512bb94db833a60