### PR TITLE
Enhance UX with personalization and improved forms

### DIFF
--- a/app/bills/[id]/edit/page.tsx
+++ b/app/bills/[id]/edit/page.tsx
@@ -81,7 +81,7 @@ export default function EditBillPage() {
     if (res.ok) {
       router.push('/bills');
     } else {
-      toast.error('❌ Ocurrió un error al actualizar la factura.');
+      toast.error('Ocurrió un error al actualizar la factura.', { icon: '❌' });
     }
   };
 

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -26,9 +26,9 @@ export default function BillsPage() {
 
     try {
       await deleteBill(id);
-      toast.success('Factura eliminada correctamente');
+      toast.success('Factura eliminada correctamente', { icon: '✅' });
     } catch {
-      toast.error('Ocurrió un error al eliminar la factura.');
+      toast.error('Ocurrió un error al eliminar la factura.', { icon: '❌' });
     }
   };
 

--- a/app/new-bill/page.tsx
+++ b/app/new-bill/page.tsx
@@ -13,6 +13,7 @@ export default function NewBillPage() {
   const [dragOver, setDragOver] = useState(false);
   const [loading, setLoading] = useState(false);
   const [textInput, setTextInput] = useState('');
+  const [step, setStep] = useState<'method' | 'text' | 'image'>('method');
 
   const router = useRouter();
 
@@ -50,13 +51,13 @@ export default function NewBillPage() {
     setLoading(false);
 
     if (data.success) {
-      toast.success('✅ Imagen procesada correctamente.');
+      toast.success('Imagen procesada correctamente.', { icon: '✅' });
       URL.revokeObjectURL(previewUrl!);
       setFile(null);
       setPreviewUrl(null);
       router.push('/bills');
     } else {
-      toast.error(data.error || '❌ Error al procesar la imagen.');
+      toast.error(data.error || 'Error al procesar la imagen.', { icon: '❌' });
     }
   };
 
@@ -75,11 +76,11 @@ export default function NewBillPage() {
     setLoading(false);
 
     if (data.success) {
-      toast.success('✅ Gasto registrado correctamente.');
+      toast.success('Gasto registrado correctamente.', { icon: '✅' });
       setTextInput('');
       router.push('/bills');
     } else {
-      toast.error('❌ Error al registrar el gasto.');
+      toast.error('Error al registrar el gasto.', { icon: '❌' });
     }
   };
 
@@ -96,82 +97,113 @@ export default function NewBillPage() {
           Registrar Factura
         </h1>
 
-        {/* Entrada de texto */}
-        <div>
-          <h2 className="font-semibold text-gray-800 mb-2">Registrar por texto</h2>
-          <textarea
-            rows={4}
-            placeholder="Ej: 5000 colones a pulpería"
-            className="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-primary"
-            value={textInput}
-            onChange={(e) => setTextInput(e.target.value)}
-          />
-          <button
-            className="mt-2 px-4 py-2 bg-primary hover:bg-primary/90 text-white font-medium rounded"
-            onClick={handleSubmitText}
-            disabled={loading || !textInput.trim()}
-          >
-            {loading ? 'Procesando...' : 'Procesar texto'}
-          </button>
-        </div>
-
-        {/* Subida o arrastre de imagen */}
-        <div>
-          <h2 className="font-semibold text-gray-800 mb-2">Subir o arrastrar imagen</h2>
-          <div
-            className={`w-full border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition ${
-              dragOver ? 'border-primary bg-primary/10' : 'border-gray-300'
-            }`}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setDragOver(true);
-            }}
-            onDragLeave={() => setDragOver(false)}
-            onDrop={handleDrop}
-            onClick={() => document.getElementById('fileInput')?.click()}
-          >
-            {file ? (
-              <p className="text-sm text-gray-600">
-                Archivo seleccionado: <strong>{file.name}</strong>
-              </p>
-            ) : (
-              <p className="text-sm text-gray-500">
-                Arrastra una imagen aquí o haz clic para seleccionar
-              </p>
-            )}
+        {step === 'method' && (
+          <div className="flex flex-col gap-4">
+            <button
+              className="px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-md"
+              onClick={() => setStep('text')}
+            >
+              Registrar por texto
+            </button>
+            <button
+              className="px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-md"
+              onClick={() => setStep('image')}
+            >
+              Subir o arrastrar imagen
+            </button>
           </div>
+        )}
 
-          {previewUrl && (
-            <div className="mt-3 text-center">
-              <p className="text-sm text-gray-600 mb-1">Vista previa:</p>
-              <img
-                src={previewUrl}
-                alt="Vista previa de la factura"
-                className="max-h-48 mx-auto rounded border"
-              />
+        {step === 'text' && (
+          <div>
+            <h2 className="font-semibold text-gray-800 mb-2">Registrar por texto</h2>
+            <textarea
+              rows={4}
+              placeholder="Ej: 5000 colones a pulpería"
+              className="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-primary"
+              value={textInput}
+              onChange={(e) => setTextInput(e.target.value)}
+            />
+            <button
+              className="mt-2 px-4 py-2 bg-primary hover:bg-primary/90 text-white font-medium rounded"
+              onClick={handleSubmitText}
+              disabled={loading || !textInput.trim()}
+            >
+              {loading ? 'Procesando...' : 'Procesar texto'}
+            </button>
+            <button
+              className="mt-2 text-sm text-primary underline"
+              onClick={() => setStep('method')}
+            >
+              Volver
+            </button>
+          </div>
+        )}
+
+        {step === 'image' && (
+          <div>
+            <h2 className="font-semibold text-gray-800 mb-2">Subir o arrastrar imagen</h2>
+            <div
+              className={`w-full border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition ${
+                dragOver ? 'border-primary bg-primary/10' : 'border-gray-300'
+              }`}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={handleDrop}
+              onClick={() => document.getElementById('fileInput')?.click()}
+            >
+              {file ? (
+                <p className="text-sm text-gray-600">
+                  Archivo seleccionado: <strong>{file.name}</strong>
+                </p>
+              ) : (
+                <p className="text-sm text-gray-500">
+                  Arrastra una imagen aquí o haz clic para seleccionar
+                </p>
+              )}
             </div>
-          )}
 
-          <input
-            id="fileInput"
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={(e) => handleFileChange(e.target.files?.[0] || null)}
-          />
+            {previewUrl && (
+              <div className="mt-3 text-center">
+                <p className="text-sm text-gray-600 mb-1">Vista previa:</p>
+                <img
+                  src={previewUrl}
+                  alt="Vista previa de la factura"
+                  className="max-h-48 mx-auto rounded border"
+                />
+              </div>
+            )}
 
-          <button
-            onClick={handleUpload}
-            disabled={!file || loading}
-            className={`mt-3 w-full px-4 py-2 rounded text-white font-medium transition ${
-              loading || !file
-                ? 'bg-gray-400 cursor-not-allowed'
-                : 'bg-primary hover:bg-primary/90'
-            }`}
-          >
-            {loading ? 'Procesando...' : 'Subir y procesar'}
-          </button>
-        </div>
+            <input
+              id="fileInput"
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => handleFileChange(e.target.files?.[0] || null)}
+            />
+
+            <button
+              onClick={handleUpload}
+              disabled={!file || loading}
+              className={`mt-3 w-full px-4 py-2 rounded text-white font-medium transition ${
+                loading || !file
+                  ? 'bg-gray-400 cursor-not-allowed'
+                  : 'bg-primary hover:bg-primary/90'
+              }`}
+            >
+              {loading ? 'Procesando...' : 'Subir y procesar'}
+            </button>
+            <button
+              className="mt-2 text-sm text-primary underline"
+              onClick={() => setStep('method')}
+            >
+              Volver
+            </button>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,46 @@
 //app/page.tsx
+'use client';
 
 import MainContent from "@/components/MainContent";
+import useBills from "@/src/hooks/useBills";
+import useUser from "@/src/hooks/useUser";
 
 export default function Home() {
+  const { bills } = useBills();
+  const { name } = useUser();
+
+  const now = new Date();
+  const monthlyBills = bills.filter((b) => {
+    const d = new Date(b.date);
+    return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear();
+  });
+  const totalThisMonth = monthlyBills.reduce((sum, b) => sum + b.total, 0);
+  const vendorTotals: Record<string, number> = {};
+  monthlyBills.forEach((b) => {
+    const vendor = b.vendor || 'Desconocido';
+    vendorTotals[vendor] = (vendorTotals[vendor] || 0) + b.total;
+  });
+  const topVendor = Object.entries(vendorTotals).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '-';
+  const budget = 250000;
+  const progress = Math.min((totalThisMonth / budget) * 100, 100);
+
   return (
     <main className="relative flex flex-col items-center justify-center min-h-screen px-4 py-10 bg-gradient-to-br from-gray-100 to-gray-200 overflow-hidden">
       <div className="absolute inset-0 pointer-events-none opacity-10 bg-[url('/globe.svg')] bg-repeat" />
       <section className="relative max-w-3xl text-center space-y-6 z-10">
         <div className="space-y-1">
           <h1 className="text-4xl sm:text-5xl font-extrabold text-primary">
-            {/* TODO: reemplazar con nombre de usuario autenticado */}
-            Hola, Manuel Rojas <span className="inline-block">👋</span>
+            Hola, {name} <span className="inline-block">👋</span>
           </h1>
           <p className="text-gray-700 text-lg sm:text-xl">
-            Gastos este mes: ₡125,300 · Top proveedor: Walmart
+            Gastos este mes: {totalThisMonth.toLocaleString('es-CR', { style: 'currency', currency: 'CRC' })} · Top proveedor: {topVendor}
           </p>
+          <div className="w-full bg-gray-200 rounded-full h-2 mt-2">
+            <div
+              className="bg-primary h-full rounded-full"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
         </div>
         <MainContent />
       </section>

--- a/components/bills/BillsFilters.tsx
+++ b/components/bills/BillsFilters.tsx
@@ -38,8 +38,9 @@ export default function BillsFilters({
   return (
     <div className="mb-4 flex flex-wrap gap-4 items-end">
       <div>
-        <label className="mr-2 font-medium">Filtrar por categoría:</label>
+        <label htmlFor="filter-category" className="mr-2 font-medium">Filtrar por categoría:</label>
         <select
+          id="filter-category"
           value={category}
           onChange={(e) => onCategoryChange(e.target.value)}
           className="border border-gray-300 px-3 py-2 rounded-md"
@@ -54,8 +55,9 @@ export default function BillsFilters({
       </div>
 
       <div>
-        <label className="mr-2 font-medium">Buscar:</label>
+        <label htmlFor="filter-search" className="mr-2 font-medium">Buscar:</label>
         <input
+          id="filter-search"
           type="text"
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
@@ -65,8 +67,9 @@ export default function BillsFilters({
       </div>
 
       <div>
-        <label className="mr-2 font-medium">Desde:</label>
+        <label htmlFor="filter-from" className="mr-2 font-medium">Desde:</label>
         <input
+          id="filter-from"
           type="date"
           value={startDate}
           onChange={(e) => onStartDateChange(e.target.value)}
@@ -75,8 +78,9 @@ export default function BillsFilters({
       </div>
 
       <div>
-        <label className="mr-2 font-medium">Hasta:</label>
+        <label htmlFor="filter-to" className="mr-2 font-medium">Hasta:</label>
         <input
+          id="filter-to"
           type="date"
           value={endDate}
           onChange={(e) => onEndDateChange(e.target.value)}

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,6 @@
+'use client';
+
+export default function useUser() {
+  // Placeholder for authenticated user information
+  return { name: 'Manuel Rojas' };
+}


### PR DESCRIPTION
## Summary
- add placeholder `useUser` hook
- personalize home page with spending summary and progress bar
- turn new bill form into step-based workflow
- show toast icons for success/error
- improve delete/edit notifications
- label inputs properly for accessibility

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c76dd0a883219254da7708930f1c