### PR TITLE
Add NextAuth authentication

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,34 @@
+import NextAuth from 'next-auth'
+import type { NextAuthOptions } from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+import { PrismaAdapter } from '@auth/prisma-adapter'
+import { prisma } from '@/lib/prisma'
+import { createHash } from 'crypto'
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: 'Email', type: 'text', placeholder: 'you@example.com' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null
+        const user = await prisma.user.findUnique({ where: { email: credentials.email } })
+        if (!user) return null
+        const hashed = createHash('sha256').update(credentials.password).digest('hex')
+        if (user.password !== hashed) return null
+        return user
+      },
+    }),
+  ],
+  session: {
+    strategy: 'database',
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+}
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,12 +1,18 @@
 // app/api/expenses/[id]/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { prisma } from '@/lib/prisma'; 
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/route';
 
 export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const id = parseInt(params.id);
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ success: false, message: 'No autorizado' }, { status: 401 });
+  }
 
   try {
     const expense = await prisma.expense.findUnique({
@@ -33,6 +39,10 @@ export async function PUT(
 ) {
   const id = parseInt(params.id);
   const body = await req.json();
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ success: false, message: 'No autorizado' }, { status: 401 });
+  }
 
   try {
     const updated = await prisma.expense.update({
@@ -59,6 +69,10 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
+    }
     const id = parseInt(params.id);
     if (isNaN(id)) {
       return NextResponse.json({ success: false, error: 'ID inválido' }, { status: 400 });

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -2,9 +2,15 @@
 
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../auth/[...nextauth]/route';
 
 export async function POST(request: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
+    }
     const body = await request.json();
     const { source, expense } = body;
 
@@ -20,6 +26,7 @@ export async function POST(request: Request) {
     const newExpense = await prisma.expense.create({
       data: {
         sourceId: newSource.id,
+        userId: (session.user as any).id,
         vendor: expense.vendor,
         description: expense.description,
         date: new Date(expense.date),
@@ -39,6 +46,10 @@ export async function POST(request: Request) {
 
 export async function GET() {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
+    }
     const expenses = await prisma.expense.findMany({
       orderBy: { date: 'desc' },
       include: {
@@ -56,6 +67,10 @@ export async function GET() {
 
 export async function DELETE(request: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
+    }
     const { id } = await request.json();
 
     const deletedExpense = await prisma.expense.delete({
@@ -71,6 +86,10 @@ export async function DELETE(request: Request) {
 
 export async function PUT(request: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
+    }
     const { id, source, expense } = await request.json();
 
     const updatedSource = await prisma.source.update({
@@ -87,6 +106,7 @@ export async function PUT(request: Request) {
       where: { id },
       data: {
         sourceId: updatedSource.id,
+        userId: (session.user as any).id,
         vendor: expense.vendor,
         description: expense.description,
         date: new Date(expense.date),

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -3,7 +3,8 @@
 
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
 import BillList from '@/components/bills/BillList';
 import BillsFilters from '@/components/bills/BillsFilters';
 import FloatingButton from '@/components/ui/FloatingButton';
@@ -11,11 +12,18 @@ import useBills from '@/src/hooks/useBills';
 
 export default function BillsPage() {
   const router = useRouter();
+  const { status } = useSession();
   const { bills, error, isLoading, deleteBill } = useBills();
   const [categoryFilter, setCategoryFilter] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+    }
+  }, [status, router]);
 
   const handleEdit = (id: number) => {
     router.push(`/bills/${id}/edit`);
@@ -42,6 +50,10 @@ export default function BillsPage() {
                       (!endDate || new Date(gasto.date) <= new Date(endDate));
     return matchCategory && matchSearch && matchDate;
   });
+
+  if (status === 'loading') {
+    return <p className="p-6">Cargando...</p>;
+  }
 
   return (
     <main className="relative min-h-screen px-4 py-10 bg-gradient-to-br from-gray-100 to-gray-200 overflow-hidden">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css";
 import NavBar from "@/components/NavBar";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css"
+import { SessionProvider } from 'next-auth/react'
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -37,8 +38,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${inter.variable} font-sans bg-secondary text-gray-900`}
       >
-        <NavBar />
-        <main className="min-h-screen">{children}</main>
+        <SessionProvider>
+          <NavBar />
+          <main className="min-h-screen">{children}</main>
+        </SessionProvider>
         <ToastContainer/>
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const router = useRouter()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await signIn('credentials', {
+      redirect: false,
+      email,
+      password,
+    })
+    if (res?.error) {
+      setError('Credenciales incorrectas')
+    } else {
+      router.push('/bills')
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-bold text-center">Iniciar sesión</h1>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          className="w-full border p-2 rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Contraseña"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          className="w-full border p-2 rounded"
+          required
+        />
+        <button type="submit" className="w-full bg-primary text-white py-2 rounded">Ingresar</button>
+      </form>
+    </main>
+  )
+}

--- a/app/logout/page.tsx
+++ b/app/logout/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { signOut } from 'next-auth/react'
+import { useEffect } from 'react'
+
+export default function LogoutPage() {
+  useEffect(() => {
+    signOut({ callbackUrl: '/login' })
+  }, [])
+  return (
+    <main className="min-h-screen flex items-center justify-center">
+      <p>Cerrando sesión...</p>
+    </main>
+  )
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
 
 export default function NavBar() {
   const [open, setOpen] = useState(false)
@@ -78,23 +79,35 @@ export default function NavBar() {
 }
 
 function NavLinks() {
+  const { status } = useSession()
   return (
     <>
       <Link href="/" className="text-gray-700 hover:text-primary font-medium transition">Inicio</Link>
       <Link href="/bills" className="text-gray-700 hover:text-primary font-medium transition">Facturas</Link>
       <Link href="/analytics" className="text-gray-700 hover:text-primary font-medium transition">Reportes</Link>
       <Link href="/settings" className="text-gray-700 hover:text-primary font-medium transition">Configuración</Link>
+      {status === 'authenticated' ? (
+        <Link href="/logout" className="text-gray-700 hover:text-primary font-medium transition">Salir</Link>
+      ) : (
+        <Link href="/login" className="text-gray-700 hover:text-primary font-medium transition">Ingresar</Link>
+      )}
     </>
   )
 }
 
 function MobileNavLinks({ onClick }: { onClick: () => void }) {
+  const { status } = useSession()
   return (
     <div className="flex flex-col space-y-3">
       <Link href="/" className="text-gray-800 hover:text-primary font-medium" onClick={onClick}>Inicio</Link>
       <Link href="/bills" className="text-gray-800 hover:text-primary font-medium" onClick={onClick}>Facturas</Link>
       <Link href="/analytics" className="text-gray-800 hover:text-primary font-medium" onClick={onClick}>Reportes</Link>
       <Link href="/settings" className="text-gray-800 hover:text-primary font-medium" onClick={onClick}>Configuración</Link>
+      {status === 'authenticated' ? (
+        <Link href="/logout" className="text-gray-800 hover:text-primary font-medium" onClick={onClick}>Salir</Link>
+      ) : (
+        <Link href="/login" className="text-gray-800 hover:text-primary font-medium" onClick={onClick}>Ingresar</Link>
+      )}
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "framer-motion": "^11.0.0",
     "swr": "^2.3.3",
     "xlsx": "^0.18.5",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "next-auth": "^4.22.1",
+    "@auth/prisma-adapter": "^1.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Source {
 model Expense {
   id             Int               @id @default(autoincrement())
   sourceId       Int
+  userId         Int
   vendor         String?           @db.VarChar(100)
   description    String            @db.VarChar(255)
   date           DateTime
@@ -63,6 +64,7 @@ model Expense {
   updatedAt      DateTime          @updatedAt
 
   source         Source            @relation(fields: [sourceId], references: [id])
+  user           User              @relation(fields: [userId], references: [id])
   invoiceDetails InvoiceDetail[]
 }
 
@@ -75,5 +77,56 @@ model InvoiceDetail {
   unitPrice      Float
 
   expense        Expense   @relation(fields: [expenseId], references: [id])
+}
+
+model User {
+  id        Int       @id @default(autoincrement())
+  name      String?
+  email     String    @unique
+  password  String
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  expenses  Expense[]
+  accounts  Account[]
+  sessions  Session[]
+}
+
+model Account {
+  id                 Int       @id @default(autoincrement())
+  userId             Int
+  type               String
+  provider           String
+  providerAccountId  String
+  refresh_token      String?   @db.Text
+  access_token       String?   @db.Text
+  expires_at         Int?
+  token_type         String?
+  scope              String?
+  id_token           String?   @db.Text
+  session_state      String?
+  oauth_token_secret String?   @db.Text
+  oauth_token        String?   @db.Text
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           Int       @id @default(autoincrement())
+  sessionToken String    @unique
+  userId       Int
+  expires      DateTime
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
 }
 


### PR DESCRIPTION
## Summary
- add Prisma User model with auth tables
- configure NextAuth with Prisma adapter and credentials provider
- protect expenses endpoints and bills page with session checks
- add login and logout pages
- display sign in/out links in the navbar and wrap the app with SessionProvider
- remove example env file and revert README/gitignore

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cef887b8832191c5408568250d5a