### PR TITLE
Fix client directive position

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,5 +1,5 @@
-// app/analytics/page.tsx
 'use client';
+// app/analytics/page.tsx
 
 import useSWR from 'swr';
 import { saveAs } from 'file-saver';

--- a/app/bills/[id]/edit/page.tsx
+++ b/app/bills/[id]/edit/page.tsx
@@ -1,6 +1,5 @@
-//app/bills/[id]/edit/page.tsx
-
 'use client';
+//app/bills/[id]/edit/page.tsx
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -1,5 +1,5 @@
-// app/bills/page.tsx
 'use client';
+// app/bills/page.tsx
 
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';

--- a/app/new-bill/page.tsx
+++ b/app/new-bill/page.tsx
@@ -1,6 +1,5 @@
-//app/new-bill/page.tsx
-
 'use client';
+//app/new-bill/page.tsx
 
 import { useState, DragEvent } from 'react';
 import { toast } from 'react-toastify';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-//app/page.tsx
 'use client';
+//app/page.tsx
 
 import MainContent from "@/components/MainContent";
 import useBills from "@/src/hooks/useBills";

--- a/components/ui/GoBackButton.tsx
+++ b/components/ui/GoBackButton.tsx
@@ -1,6 +1,5 @@
-//components/ui/GoBackButton.tsx
-
 'use client';
+//components/ui/GoBackButton.tsx
 
 import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';


### PR DESCRIPTION
## Summary
- move `'use client'` directives to the first line of files that use hooks

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685985d2b0908321b5d056dcde24dafa