### PR TITLE
Wrap layout with providers

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,5 +1,5 @@
-// app/analytics/page.tsx
 'use client';
+// app/analytics/page.tsx
 
 import useSWR from 'swr';
 import { saveAs } from 'file-saver';

--- a/app/bills/[id]/edit/page.tsx
+++ b/app/bills/[id]/edit/page.tsx
@@ -1,6 +1,5 @@
-//app/bills/[id]/edit/page.tsx
-
 'use client';
+//app/bills/[id]/edit/page.tsx
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';

--- a/app/bills/page.tsx
+++ b/app/bills/page.tsx
@@ -1,5 +1,5 @@
-// app/bills/page.tsx
 'use client';
+// app/bills/page.tsx
 
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import "./globals.css";
 import NavBar from "@/components/NavBar";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css"
-import { SessionProvider } from 'next-auth/react'
+import Providers from '@/components/Providers'
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,10 +38,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${inter.variable} font-sans bg-secondary text-gray-900`}
       >
-        <SessionProvider>
+        <Providers>
           <NavBar />
           <main className="min-h-screen">{children}</main>
-        </SessionProvider>
+        </Providers>
         <ToastContainer/>
       </body>
     </html>

--- a/app/new-bill/page.tsx
+++ b/app/new-bill/page.tsx
@@ -1,6 +1,5 @@
-//app/new-bill/page.tsx
-
 'use client';
+//app/new-bill/page.tsx
 
 import { useState, DragEvent } from 'react';
 import { toast } from 'react-toastify';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-//app/page.tsx
 'use client';
+//app/page.tsx
 
 import MainContent from "@/components/MainContent";
 import useBills from "@/src/hooks/useBills";

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { SessionProvider } from 'next-auth/react'
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/components/ui/GoBackButton.tsx
+++ b/components/ui/GoBackButton.tsx
@@ -1,6 +1,5 @@
-//components/ui/GoBackButton.tsx
-
 'use client';
+//components/ui/GoBackButton.tsx
 
 import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import { withAuth } from "next-auth/middleware";
+
+export default withAuth({
+  pages: {
+    signIn: "/login",
+  },
+});
+
+export const config = {
+  matcher: ["/((?!api|_next|favicon.ico|login|logout).*)"],
+};


### PR DESCRIPTION
## Summary
- remove the `use client` directive from `app/layout.tsx`
- move the NextAuth `SessionProvider` to a new `Providers` client component
- protect all pages with NextAuth middleware

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685985d2b0908321b5d056dcde24dafa