### PR TITLE
Update useUser to use session

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
       <section className="relative max-w-3xl text-center space-y-6 z-10">
         <div className="space-y-1">
           <h1 className="text-4xl sm:text-5xl font-extrabold text-primary">
-            Hola, {name} <span className="inline-block">👋</span>
+            Hola, {name ?? 'Usuario'} <span className="inline-block">👋</span>
           </h1>
           <p className="text-gray-700 text-lg sm:text-xl">
             Gastos este mes: {totalThisMonth.toLocaleString('es-CR', { style: 'currency', currency: 'CRC' })} · Top proveedor: {topVendor}

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,6 +1,12 @@
-'use client';
+'use client'
+
+import { useSession } from 'next-auth/react'
 
 export default function useUser() {
-  // Placeholder for authenticated user information
-  return { name: 'Manuel Rojas' };
+  const { data: session } = useSession()
+  return {
+    name: session?.user?.name ?? null,
+    email: session?.user?.email ?? null,
+    id: (session?.user as any)?.id,
+  }
 }


### PR DESCRIPTION
## Summary
- use `useSession` in `useUser` hook
- show fallback username when none is available

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859917b510c8321a7d2868a7afa4c34