### PR TITLE
Use session user in processBill routes

### DIFF
--- a/app/api/processBill/bill-photo/route.ts
+++ b/app/api/processBill/bill-photo/route.ts
@@ -3,9 +3,18 @@ import { openai } from '@/lib/openai';
 import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
 import { ExpenseWithDetailsSchema } from '@/src/schema';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/route';
 
 export async function POST(req: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json(
+        { success: false, error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
     const formData = await req.formData();
     const file = formData.get('file') as File;
 
@@ -112,7 +121,7 @@ Devuelve SOLO un JSON con esta estructura con la información extraída:
         currency: data.moneda,
         expenseType: data.tipo,
         category: data.categoria,
-        userId: 1, // Asumiendo un usuario por defecto, ajustar según tu lógica de autenticación
+        userId: session.user.id,
       },
     });
 

--- a/app/api/processBill/text/route.ts
+++ b/app/api/processBill/text/route.ts
@@ -4,9 +4,18 @@ import { openai } from '@/lib/openai';
 import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
 import { ExpenseWithDetailsSchema } from '@/src/schema';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/route';
 
 export async function POST(req: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json(
+        { success: false, error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
     const { message } = await req.json();
 
     const prompt = `
@@ -93,7 +102,7 @@ Texto: ${message}
         currency: data.moneda,
         expenseType: data.tipo,
         category: data.categoria ?? 'OTHER',
-        userId: 1, // Asumiendo un usuario por defecto, ajustar según tu lógica de autenticación
+        userId: session.user.id,
       },
     });
 


### PR DESCRIPTION
## Summary
- get the server session in bill-photo and text bill processing routes
- associate expenses with `session.user.id`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599163ad80832183803fc58993ee84