### PR TITLE
Fix userId in NextAuth session

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -29,6 +29,14 @@ export const authOptions: NextAuthOptions = {
   session: {
     strategy: 'jwt',
   },
+  callbacks: {
+    async session({ session, token }) {
+      if (session.user && token.sub) {
+        (session.user as any).id = token.sub
+      }
+      return session
+    },
+  },
   secret: process.env.NEXTAUTH_SECRET,
 }
 

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,9 @@
+import NextAuth, { DefaultSession, DefaultUser } from 'next-auth'
+
+declare module 'next-auth' {
+  interface Session {
+    user: DefaultUser & {
+      id: string
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- ensure NextAuth session exposes `user.id`
- type declaration for NextAuth session

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cc84c0e88321a2f3710a6d019983