### PR TITLE
Add dynamic budget setting

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -5,15 +5,6 @@ import useSWR from 'swr';
 import { saveAs } from 'file-saver';
 import * as XLSX from 'xlsx';
 
-interface Expense {
-  id: number;
-  vendor: string | null;
-  description: string;
-  total: number;
-  currency: string;
-  date: string;
-  category?: string;
-}
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
 
@@ -26,7 +17,7 @@ export default function AnalyticsPage() {
     const wb = XLSX.utils.book_new();
 
     Object.entries(data.data).forEach(([sheetName, rows]) => {
-      const ws = XLSX.utils.json_to_sheet(rows as any[]);
+      const ws = XLSX.utils.json_to_sheet(rows as unknown[]);
       XLSX.utils.book_append_sheet(wb, ws, sheetName);
     });
 

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -32,7 +32,7 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async session({ session, token }) {
       if (session.user && token.sub) {
-        (session.user as any).id = token.sub
+        (session.user as { id?: string }).id = token.sub
       }
       return session
     },

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -28,7 +28,7 @@ export async function GET(
     }
 
     return NextResponse.json({ success: true, data: expense });
-  } catch (error) {
+  } catch {
     return NextResponse.json({ success: false, message: 'Error interno' }, { status: 500 });
   }
 }
@@ -57,7 +57,7 @@ export async function PUT(
     });
 
     return NextResponse.json({ success: true, data: updated });
-  } catch (error) {
+  } catch {
     return NextResponse.json({ success: false, message: 'Error al actualizar' }, { status: 500 });
   }
 }
@@ -103,8 +103,8 @@ export async function DELETE(
     });
 
     return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error('[DELETE /expenses/:id]', error);
+  } catch {
+    console.error('[DELETE /expenses/:id]');
     return NextResponse.json({ success: false, error: 'Error al eliminar la factura' }, { status: 500 });
   }
 }

--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: Request) {
     const newExpense = await prisma.expense.create({
       data: {
         sourceId: newSource.id,
-        userId: (session.user as any).id,
+        userId: (session.user as { id: number }).id,
         vendor: expense.vendor,
         description: expense.description,
         date: new Date(expense.date),
@@ -106,7 +106,7 @@ export async function PUT(request: Request) {
       where: { id },
       data: {
         sourceId: updatedSource.id,
-        userId: (session.user as any).id,
+        userId: (session.user as { id: number }).id,
         vendor: expense.vendor,
         description: expense.description,
         date: new Date(expense.date),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,10 +4,12 @@
 import MainContent from "@/components/MainContent";
 import useBills from "@/src/hooks/useBills";
 import useUser from "@/src/hooks/useUser";
+import useBudget from "@/src/hooks/useBudget";
 
 export default function Home() {
   const { bills } = useBills();
   const { name } = useUser();
+  const { budget } = useBudget();
 
   const now = new Date();
   const monthlyBills = bills.filter((b) => {
@@ -21,7 +23,6 @@ export default function Home() {
     vendorTotals[vendor] = (vendorTotals[vendor] || 0) + b.total;
   });
   const topVendor = Object.entries(vendorTotals).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '-';
-  const budget = 250000;
   const progress = Math.min((totalThisMonth / budget) * 100, 100);
 
   return (
@@ -35,11 +36,15 @@ export default function Home() {
           <p className="text-gray-700 text-lg sm:text-xl">
             Gastos este mes: {totalThisMonth.toLocaleString('es-CR', { style: 'currency', currency: 'CRC' })} · Top proveedor: {topVendor}
           </p>
-          <div className="w-full bg-gray-200 rounded-full h-2 mt-2">
+          <div className="relative w-full bg-gray-200 rounded-full h-4 mt-2 overflow-hidden">
             <div
-              className="bg-primary h-full rounded-full"
+              className="bg-primary h-full rounded-full transition-all"
               style={{ width: `${progress}%` }}
             />
+            <span className="absolute inset-0 flex items-center justify-center text-xs font-medium text-gray-800">
+              {totalThisMonth.toLocaleString('es-CR', { style: 'currency', currency: 'CRC' })} /
+              {budget.toLocaleString('es-CR', { style: 'currency', currency: 'CRC' })}
+            </span>
           </div>
         </div>
         <MainContent />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,8 +1,16 @@
 'use client';
 
 import GoBackButton from '@/components/ui/GoBackButton';
+import { useState, useEffect } from 'react';
+import useBudget from '@/src/hooks/useBudget';
 
 export default function SettingsPage() {
+  const { budget, setBudget } = useBudget();
+  const [value, setValue] = useState(budget);
+
+  useEffect(() => {
+    setValue(budget);
+  }, [budget]);
   const suggestions = [
     'Actualizar datos personales',
     'Preferencias de notificación',
@@ -24,6 +32,26 @@ export default function SettingsPage() {
         A continuación se muestran algunas ideas de ajustes que podrías incluir
         en tu aplicación para mejorar la experiencia de usuario:
       </p>
+      <div className="space-y-2">
+        <label htmlFor="budget" className="font-medium text-gray-800 block">
+          Presupuesto mensual (CRC)
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="budget"
+            type="number"
+            value={value}
+            onChange={(e) => setValue(parseInt(e.target.value))}
+            className="border border-gray-300 px-3 py-2 rounded-md w-full"
+          />
+          <button
+            className="px-4 py-2 bg-primary text-white rounded-md"
+            onClick={() => setBudget(value)}
+          >
+            Guardar
+          </button>
+        </div>
+      </div>
       <ul className="list-disc pl-6 space-y-2 text-gray-800">
         {suggestions.map((item) => (
           <li key={item}>{item}</li>

--- a/components/MainContent.tsx
+++ b/components/MainContent.tsx
@@ -16,7 +16,7 @@ export default function MainContent() {
     if (!data || !data.success) return;
     const wb = XLSX.utils.book_new();
     Object.entries(data.data).forEach(([sheetName, rows]) => {
-      const ws = XLSX.utils.json_to_sheet(rows as any[]);
+      const ws = XLSX.utils.json_to_sheet(rows as unknown[]);
       XLSX.utils.book_append_sheet(wb, ws, sheetName);
     });
     const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,9 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: ["node_modules/**", "lib/generated/**", ".next/**"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/src/hooks/useBudget.ts
+++ b/src/hooks/useBudget.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+const STORAGE_KEY = 'monthlyBudget'
+
+export default function useBudget() {
+  const [budget, setBudgetState] = useState<number>(250000)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const value = parseInt(stored, 10)
+      if (!isNaN(value)) {
+        setBudgetState(value)
+      }
+    }
+  }, [])
+
+  const setBudget = (value: number) => {
+    setBudgetState(value)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, value.toString())
+    }
+  }
+
+  return { budget, setBudget }
+}

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -7,6 +7,6 @@ export default function useUser() {
   return {
     name: session?.user?.name ?? null,
     email: session?.user?.email ?? null,
-    id: (session?.user as any)?.id,
+    id: (session?.user as { id?: string })?.id,
   }
 }


### PR DESCRIPTION
## Summary
- introduce `useBudget` hook for managing monthly budget in localStorage
- show current spending progress using the stored budget on home page
- allow updating the monthly budget from the settings screen
- fix lint warnings and configure ESLint ignores

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859d077d04c8321870d8f36f69bf921