### PR TITLE
Secure user endpoints

### DIFF
--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -22,10 +22,22 @@ export async function PUT(request: Request) {
   const userId = Number((session.user as { id: string }).id)
   const { preferredCurrency, exchangeRate, monthlyBudget } = body
   try {
+    const updateData: Record<string, unknown> = {}
+    if (preferredCurrency !== undefined) updateData.preferredCurrency = preferredCurrency
+    if (exchangeRate !== undefined) updateData.exchangeRate = exchangeRate
+    if (monthlyBudget !== undefined) updateData.monthlyBudget = monthlyBudget
+
+    const createData = {
+      userId,
+      preferredCurrency: preferredCurrency ?? 'CRC',
+      monthlyBudget: monthlyBudget ?? 0,
+    } as Record<string, unknown>
+    if (exchangeRate !== undefined) createData.exchangeRate = exchangeRate
+
     const updated = await prisma.setting.upsert({
       where: { userId },
-      update: { preferredCurrency, exchangeRate, monthlyBudget },
-      create: { userId, preferredCurrency, exchangeRate, monthlyBudget },
+      update: updateData,
+      create: createData,
     })
     return NextResponse.json({ success: true, data: updated })
   } catch (error) {


### PR DESCRIPTION
## Summary
- sanitize updates in settings API
- require auth on export endpoint
- scope expenses APIs by user

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859efc8edd88321be07dee7ef70d917