### PR TITLE
Fix settings upsert types

### DIFF
--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import type { Prisma } from '@/lib/generated/prisma'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]/route'
 
@@ -22,16 +23,16 @@ export async function PUT(request: Request) {
   const userId = Number((session.user as { id: string }).id)
   const { preferredCurrency, exchangeRate, monthlyBudget } = body
   try {
-    const updateData: Record<string, unknown> = {}
+    const updateData: Prisma.SettingUncheckedUpdateInput = {}
     if (preferredCurrency !== undefined) updateData.preferredCurrency = preferredCurrency
     if (exchangeRate !== undefined) updateData.exchangeRate = exchangeRate
     if (monthlyBudget !== undefined) updateData.monthlyBudget = monthlyBudget
 
-    const createData = {
+    const createData: Prisma.SettingUncheckedCreateInput = {
       userId,
       preferredCurrency: preferredCurrency ?? 'CRC',
       monthlyBudget: monthlyBudget ?? 0,
-    } as Record<string, unknown>
+    }
     if (exchangeRate !== undefined) createData.exchangeRate = exchangeRate
 
 


### PR DESCRIPTION
## Summary
- import Prisma types in settings API
- use `SettingUncheckedUpdateInput` and `SettingUncheckedCreateInput` instead of `Record<string, unknown>`

## Testing
- `npm run build` *(fails: Failed to fetch fonts)*
- `npx tsc --noEmit` *(fails: errors in generated .next files)*

------
https://chatgpt.com/codex/tasks/task_e_685a238db1948321824f14672d4d9af7