### PR TITLE
Use RouteHandlerContext for expense API route

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,14 +1,15 @@
 // app/api/expenses/[id]/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+import type { RouteHandlerContext } from 'next';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../../auth/[...nextauth]/route';
 
 export async function GET(
-  req: NextRequest,
-  { params }: { params: { id: string } }
+  request: Request,
+  context: RouteHandlerContext<{ id: string }>
 ) {
-  const id = parseInt(params.id);
+  const id = parseInt(context.params.id);
   const session = await getServerSession(authOptions);
   if (!session) {
     return NextResponse.json({ success: false, message: 'No autorizado' }, { status: 401 });
@@ -35,11 +36,11 @@ export async function GET(
 }
 
 export async function PUT(
-  req: NextRequest,
-  { params }: { params: { id: string } }
+  request: Request,
+  context: RouteHandlerContext<{ id: string }>
 ) {
-  const id = parseInt(params.id);
-  const body = await req.json();
+  const id = parseInt(context.params.id);
+  const body = await request.json();
   const session = await getServerSession(authOptions);
   if (!session) {
     return NextResponse.json({ success: false, message: 'No autorizado' }, { status: 401 });
@@ -73,15 +74,15 @@ export async function PUT(
 
 
 export async function DELETE(
-  _req: Request,
-  { params }: { params: { id: string } }
+  request: Request,
+  context: RouteHandlerContext<{ id: string }>
 ) {
   try {
     const session = await getServerSession(authOptions);
     if (!session) {
       return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
     }
-    const id = parseInt(params.id);
+    const id = parseInt(context.params.id);
     const userId = Number((session.user as { id: string }).id);
     if (isNaN(id)) {
       return NextResponse.json({ success: false, error: 'ID inválido' }, { status: 400 });


### PR DESCRIPTION
## Summary
- use `RouteHandlerContext` type in expense route
- adjust function signatures to use the new context

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685a29daaf3c8321ad93d9b285ccff51