### PR TITLE
Fix param access in expenses API routes

### DIFF
--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -10,7 +10,7 @@ export async function GET(
   context: RouteHandlerContext<{ id: string }>
 ) {
 
-  const { id: idRaw } = await context.params;
+  const { id: idRaw } = context.params;
   const id = Number(idRaw);
   if (isNaN(id)) {
     return NextResponse.json({ success: false, message: 'ID inválido' }, { status: 400 });
@@ -46,7 +46,7 @@ export async function PUT(
   context: RouteHandlerContext<{ id: string }>
 ) {
 
-  const { id: idRaw } = await context.params;
+  const { id: idRaw } = context.params;
   const id = Number(idRaw);
   if (isNaN(id)) {
     return NextResponse.json({ success: false, message: 'ID inválido' }, { status: 400 });
@@ -94,7 +94,7 @@ export async function DELETE(
     if (!session) {
       return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
     }
-    const { id: idRaw } = await context.params;
+    const { id: idRaw } = context.params;
     const id = Number(idRaw);
 
     const userId = Number((session.user as { id: string }).id);


### PR DESCRIPTION
## Summary
- remove redundant `await` when reading `context.params`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b86147428832197bc2c70b3b5239e