### PR TITLE
Add validation for expense API

### DIFF
--- a/app/api/expenses/route.ts
+++ b/app/api/expenses/route.ts
@@ -4,6 +4,45 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../auth/[...nextauth]/route';
+import { z } from 'zod';
+
+const SourceSchema = z.object({
+  id: z.number().optional(),
+  type: z.enum(['message', 'image']),
+  description: z.string().optional(),
+  receivedAt: z.string().datetime(),
+  fileUrl: z.string().url().nullable().optional(),
+});
+
+const ExpenseSchema = z.object({
+  vendor: z.string().max(100).nullable().optional(),
+  description: z.string(),
+  date: z.string().datetime(),
+  total: z.number(),
+  currency: z.enum(['CRC', 'USD']),
+  expenseType: z.enum(['simple', 'invoice']),
+  categoria: z
+    .enum([
+      'FOOD',
+      'TRANSPORT',
+      'MEDICAL',
+      'SERVICES',
+      'SUBSCRIPTIONS',
+      'INSTALLMENTS',
+      'ENTERTAINMENT',
+      'HOUSEHOLD',
+      'EDUCATION',
+      'OTHER',
+    ])
+    .nullable()
+    .optional(),
+});
+
+const BodySchema = z.object({
+  source: SourceSchema,
+  expense: ExpenseSchema,
+  id: z.number().optional(),
+});
 
 export async function POST(request: Request) {
   try {
@@ -11,8 +50,15 @@ export async function POST(request: Request) {
     if (!session) {
       return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
     }
-    const body = await request.json();
-    const { source, expense } = body;
+    const json = await request.json();
+    const parseResult = BodySchema.safeParse(json);
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { success: false, error: parseResult.error.flatten() },
+        { status: 400 }
+      );
+    }
+    const { source, expense } = parseResult.data;
 
     const newSource = await prisma.source.create({
       data: {
@@ -94,7 +140,15 @@ export async function PUT(request: Request) {
     if (!session) {
       return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
     }
-    const { id, source, expense } = await request.json();
+    const json = await request.json();
+    const parseResult = BodySchema.safeParse(json);
+    if (!parseResult.success || parseResult.data.id === undefined) {
+      return NextResponse.json(
+        { success: false, error: parseResult.success ? 'ID requerido' : parseResult.error.flatten() },
+        { status: 400 }
+      );
+    }
+    const { id, source, expense } = parseResult.data;
     const userId = Number((session.user as { id: string }).id);
 
     const existing = await prisma.expense.findFirst({ where: { id, userId } });


### PR DESCRIPTION
## Summary
- validate POST and PUT payloads with zod

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b87d5f4f08321a82b88e5f2419499