### PR TITLE
Add usage comments to API routes

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,6 @@
+// app/api/auth/[...nextauth]/route.ts
+//
+// Usado por app/login/page.tsx y app/logout/page.tsx a través de NextAuth
 import NextAuth from 'next-auth'
 import type { NextAuthOptions } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'

--- a/app/api/expenses/[id]/route.ts
+++ b/app/api/expenses/[id]/route.ts
@@ -1,21 +1,30 @@
 // app/api/expenses/[id]/route.ts
+//
+// Usado por:
+// - app/bills/[id]/edit/page.tsx (GET y PUT)
+// - src/hooks/useBills.ts (DELETE)
 import { NextResponse } from 'next/server';
 import type { RouteHandlerContext } from 'next';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '../../auth/[...nextauth]/route';
 
+// Devuelve un gasto específico para edición
+// Utilizado en app/bills/[id]/edit/page.tsx
 export async function GET(
   request: Request,
   context: RouteHandlerContext<{ id: string }>
 ) {
 
+  // Extrae y valida el id de la ruta
+  // Id de la factura a actualizar
   const { id: idRaw } = await context.params;
   const id = Number(idRaw);
   if (isNaN(id)) {
     return NextResponse.json({ success: false, message: 'ID inválido' }, { status: 400 });
   }
 
+  // Verifica autenticación
   const session = await getServerSession(authOptions);
   if (!session) {
     return NextResponse.json({ success: false, message: 'No autorizado' }, { status: 401 });
@@ -23,6 +32,7 @@ export async function GET(
   const userId = Number((session.user as { id: string }).id);
 
   try {
+    // Busca el gasto junto con su fuente y detalles
     const expense = await prisma.expense.findFirst({
       where: { id, userId },
       include: {
@@ -32,15 +42,19 @@ export async function GET(
     });
 
     if (!expense) {
+      // No existe o no pertenece al usuario
       return NextResponse.json({ success: false, message: 'No encontrado' }, { status: 404 });
     }
 
     return NextResponse.json({ success: true, data: expense });
   } catch {
+    // Error inesperado
     return NextResponse.json({ success: false, message: 'Error interno' }, { status: 500 });
   }
 }
 
+// Actualiza un gasto existente
+// Utilizado en app/bills/[id]/edit/page.tsx
 export async function PUT(
   request: Request,
   context: RouteHandlerContext<{ id: string }>
@@ -60,6 +74,7 @@ export async function PUT(
   const userId = Number((session.user as { id: string }).id);
 
   try {
+    // Actualiza el registro en base al cuerpo recibido
     const updated = await prisma.expense.updateMany({
       where: { id, userId },
       data: {
@@ -72,28 +87,39 @@ export async function PUT(
     });
 
     if (updated.count === 0) {
+      // El gasto no existe o no pertenece al usuario
       return NextResponse.json({ success: false, message: 'No encontrado' }, { status: 404 });
     }
 
-    const refreshed = await prisma.expense.findFirst({ where: { id, userId }, include: { invoiceDetails: true, source: true } })
+    // Obtiene el registro actualizado con sus relaciones
+    const refreshed = await prisma.expense.findFirst({
+      where: { id, userId },
+      include: { invoiceDetails: true, source: true }
+    })
 
     return NextResponse.json({ success: true, data: refreshed });
   } catch {
+    // Error al actualizar en base de datos
     return NextResponse.json({ success: false, message: 'Error al actualizar' }, { status: 500 });
   }
 }
 
 
 
+// Elimina una factura y sus registros asociados
+// Llamado desde src/hooks/useBills.ts
 export async function DELETE(
   request: Request,
   context: RouteHandlerContext<{ id: string }>
 ) {
   try {
+    // Verifica autenticación
     const session = await getServerSession(authOptions);
     if (!session) {
       return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 });
     }
+
+    // Id del gasto a eliminar
     const { id: idRaw } = await context.params;
     const id = Number(idRaw);
 
@@ -102,23 +128,24 @@ export async function DELETE(
       return NextResponse.json({ success: false, error: 'ID inválido' }, { status: 400 });
     }
 
+    // Comprueba existencia
     const expense = await prisma.expense.findFirst({ where: { id, userId } });
 
     if (!expense) {
       return NextResponse.json({ success: false, error: 'Factura no encontrada' }, { status: 404 });
     }
 
-    // 1. Eliminar detalles de la factura primero
+    // Primero elimina los detalles relacionados
     await prisma.invoiceDetail.deleteMany({
       where: { expenseId: id },
     });
 
-    // 3. Eliminar el gasto
+    // Luego elimina el gasto
     await prisma.expense.delete({
       where: { id },
     });
 
-    // 4. Eliminar el source si deseas limpiarlo también
+    // Finalmente elimina el source asociado
     await prisma.source.delete({
       where: { id: expense.sourceId },
     });
@@ -126,6 +153,7 @@ export async function DELETE(
     return NextResponse.json({ success: true });
   } catch {
     console.error('[DELETE /expenses/:id]');
+    // Error al eliminar en la base de datos
     return NextResponse.json({ success: false, error: 'Error al eliminar la factura' }, { status: 500 });
   }
 }

--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -1,4 +1,8 @@
 // app/api/export/route.ts
+//
+// Usado por:
+// - components/MainContent.tsx
+// - app/analytics/page.tsx
 
 import { prisma } from '@/lib/prisma'
 import { NextResponse } from 'next/server'
@@ -6,12 +10,14 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]/route'
 
 export async function GET() {
+  // Verifica que el usuario esté autenticado
   const session = await getServerSession(authOptions)
   if (!session) {
     return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 })
   }
   const userId = Number((session.user as { id: string }).id)
   try {
+    // Obtiene todos los gastos junto con sus detalles e imágenes
     const expenses = await prisma.expense.findMany({
       where: { userId },
       include: { invoiceDetails: true, source: true },
@@ -19,6 +25,7 @@ export async function GET() {
     const invoiceDetails = expenses.flatMap(e => e.invoiceDetails)
     const sources = expenses.map(e => e.source)
 
+    // Devuelve todo en un único objeto
     return NextResponse.json({
       success: true,
       data: {
@@ -29,6 +36,7 @@ export async function GET() {
     });
   } catch (error) {
     console.error('[EXPORT API ERROR]', error);
+    // Falla al consultar la base de datos
     return NextResponse.json(
       { success: false, error: 'Error al exportar los datos' },
       { status: 500 }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,33 +1,44 @@
+// app/api/settings/route.ts
+//
+// Usado por:
+// - src/hooks/useSettings.ts (en app/page.tsx y app/settings/page.tsx)
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import type { Prisma } from '@/lib/generated/prisma'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]/route'
 
+// Obtiene la configuración del usuario actual
 export async function GET() {
+  // Verifica autenticación
   const session = await getServerSession(authOptions)
   if (!session) {
     return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 })
   }
+  // Busca la configuración única de este usuario
   const userId = Number((session.user as { id: string }).id)
   const setting = await prisma.setting.findUnique({ where: { userId } })
   return NextResponse.json({ success: true, data: setting })
 }
 
+// Actualiza o crea la configuración del usuario
 export async function PUT(request: Request) {
   const session = await getServerSession(authOptions)
   if (!session) {
     return NextResponse.json({ success: false, error: 'No autorizado' }, { status: 401 })
   }
+  // Datos enviados por el cliente
   const body = await request.json()
   const userId = Number((session.user as { id: string }).id)
   const { preferredCurrency, exchangeRate, monthlyBudget } = body
   try {
+    // Campos a actualizar
     const updateData: Prisma.SettingUncheckedUpdateInput = {}
     if (preferredCurrency !== undefined) updateData.preferredCurrency = preferredCurrency
     if (exchangeRate !== undefined) updateData.exchangeRate = exchangeRate
     if (monthlyBudget !== undefined) updateData.monthlyBudget = monthlyBudget
 
+    // Valores por defecto si no existe registro
     const createData: Prisma.SettingUncheckedCreateInput = {
       userId,
       preferredCurrency: preferredCurrency ?? 'CRC',
@@ -36,14 +47,16 @@ export async function PUT(request: Request) {
     if (exchangeRate !== undefined) createData.exchangeRate = exchangeRate
 
 
-    const updated = await prisma.setting.upsert({ 
+    // Crea o actualiza la configuración en una sola operación
+    const updated = await prisma.setting.upsert({
       where: { userId },
       update: updateData,
-      create: createData, 
+      create: createData,
     })
     return NextResponse.json({ success: true, data: updated })
   } catch (error) {
     console.error('[SETTINGS PUT ERROR]', error)
+    // Error al guardar los ajustes en la base de datos
     return NextResponse.json({ success: false, error: 'Error al guardar ajustes' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- annotate API routes with which pages use them
- add inline comments explaining major steps

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b92fc75988321bef9ab8a1081d637