### PR TITLE
Use OpenAI JSON response

### DIFF
--- a/app/api/processBill/bill-photo/route.ts
+++ b/app/api/processBill/bill-photo/route.ts
@@ -35,6 +35,7 @@ export async function POST(req: Request) {
     // Solicita a OpenAI que extraiga los datos de la factura
     const completion = await openai.chat.completions.create({
       model: 'gpt-4o',
+      response_format: { type: 'json_object' },
       messages: [
         {
           role: 'user',
@@ -89,18 +90,15 @@ Devuelve SOLO un JSON con esta estructura con la información extraída:
       ],
     });
 
-    // Respuesta en texto de OpenAI
+    // Respuesta en JSON de OpenAI
     const raw = completion.choices[0].message.content ?? '';
     console.log('🔍 GPT respuesta:', raw);
 
-    // Limpia delimitadores de código
-    const cleaned = raw.replace(/```json|```/g, '').trim();
-
     let parsedJSON;
     try {
-      parsedJSON = JSON.parse(cleaned);
+      parsedJSON = JSON.parse(raw);
     } catch (err) {
-      console.error('❌ JSON malformado:', err, cleaned);
+      console.error('❌ JSON malformado:', err, raw);
       return NextResponse.json(
         { success: false, error: 'Formato de respuesta inválido del modelo' },
         { status: 500 }

--- a/app/api/processBill/text/route.ts
+++ b/app/api/processBill/text/route.ts
@@ -74,15 +74,25 @@ Texto: ${message}
     // Envía el texto a OpenAI para extraer la información
     const completion = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
+      response_format: { type: 'json_object' },
       messages: [{ role: 'user', content: prompt }],
       temperature: 0,
     });
 
-    // Texto devuelto por OpenAI
+    // Respuesta de OpenAI en JSON
     const raw = completion.choices[0].message.content ?? '';
     console.log('🔍 Respuesta cruda de OpenAI:', raw);
 
-    const parsedJSON = JSON.parse(raw);
+    let parsedJSON;
+    try {
+      parsedJSON = JSON.parse(raw);
+    } catch (err) {
+      console.error('❌ JSON malformado:', err, raw);
+      return NextResponse.json(
+        { success: false, error: 'Formato de respuesta inválido del modelo' },
+        { status: 500 }
+      );
+    }
     // Valida el esquema recibido
     const result = ExpenseWithDetailsSchema.safeParse(parsedJSON);
     if (!result.success) {


### PR DESCRIPTION
## Summary
- configure OpenAI routes to request JSON directly using `response_format`
- remove manual response cleanup and add validation for malformed JSON

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864a09c6ab88321aa79217185b9a6bc