### PR TITLE
Add animations and toast notifications

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -45,7 +45,12 @@ export default function LoginPage() {
           className="w-full border p-2 rounded"
           required
         />
-        <button type="submit" className="w-full bg-primary text-white py-2 rounded">Ingresar</button>
+        <button
+          type="submit"
+          className="w-full bg-primary text-white py-2 rounded hover:bg-primary/90 active:scale-95 transition-transform"
+        >
+          Ingresar
+        </button>
       </form>
     </main>
   )

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -47,7 +47,7 @@ export default function LoginPage() {
         />
         <button
           type="submit"
-          className="w-full bg-primary text-white py-2 rounded hover:bg-primary/90 active:scale-95 transition-transform"
+          className="w-full bg-primary text-white py-2 rounded hover:bg-primary/90 active:scale-95 transition"
         >
           Ingresar
         </button>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import GoBackButton from '@/components/ui/GoBackButton';
 import { useState, useEffect } from 'react';
 import useSettings from '@/src/hooks/useSettings';
+import { toast } from 'react-toastify';
 
 export default function SettingsPage() {
   const { settings, saveSettings, isLoading } = useSettings();
@@ -29,12 +30,17 @@ export default function SettingsPage() {
     'Eliminar cuenta o limpiar datos',
   ];
 
-  const handleSave = () => {
-    saveSettings({
-      monthlyBudget: budget,
-      preferredCurrency: currency,
-      exchangeRate: rate,
-    });
+  const handleSave = async () => {
+    try {
+      await saveSettings({
+        monthlyBudget: budget,
+        preferredCurrency: currency,
+        exchangeRate: rate,
+      });
+      toast.success('Cambios guardados');
+    } catch {
+      toast.error('Error al guardar la configuración');
+    }
   };
 
   return (
@@ -83,7 +89,7 @@ export default function SettingsPage() {
           />
         </div>
         <button
-          className="px-4 py-2 bg-primary text-white rounded-md disabled:opacity-50"
+          className="px-4 py-2 bg-primary text-white rounded-md disabled:opacity-50 hover:bg-primary/90 active:scale-95 transition-transform"
           onClick={handleSave}
           disabled={isLoading}
         >

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -89,7 +89,7 @@ export default function SettingsPage() {
           />
         </div>
         <button
-          className="px-4 py-2 bg-primary text-white rounded-md disabled:opacity-50 hover:bg-primary/90 active:scale-95 transition-transform"
+          className="px-4 py-2 bg-primary text-white rounded-md disabled:opacity-50 hover:bg-primary/90 active:scale-95 transition"
           onClick={handleSave}
           disabled={isLoading}
         >

--- a/components/bills/BillsFilters.tsx
+++ b/components/bills/BillsFilters.tsx
@@ -36,14 +36,14 @@ export default function BillsFilters({
   onEndDateChange,
 }: BillsFiltersProps) {
   return (
-    <div className="mb-4 flex flex-wrap gap-4 items-end">
+    <div className="mb-4 flex flex-wrap gap-4 items-end text-gray-800">
       <div>
-        <label htmlFor="filter-category" className="mr-2 font-medium">Filtrar por categoría:</label>
+        <label htmlFor="filter-category" className="mr-2 font-medium text-gray-800">Filtrar por categoría:</label>
         <select
           id="filter-category"
           value={category}
           onChange={(e) => onCategoryChange(e.target.value)}
-          className="border border-gray-300 px-3 py-2 rounded-md"
+          className="border border-gray-300 px-3 py-2 rounded-md text-gray-800"
         >
           <option value="">Todas</option>
           {CATEGORIES.map((cat) => (
@@ -55,36 +55,36 @@ export default function BillsFilters({
       </div>
 
       <div>
-        <label htmlFor="filter-search" className="mr-2 font-medium">Buscar:</label>
+        <label htmlFor="filter-search" className="mr-2 font-medium text-gray-800">Buscar:</label>
         <input
           id="filter-search"
           type="text"
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
-          className="border border-gray-300 px-3 py-2 rounded-md"
+          className="border border-gray-300 px-3 py-2 rounded-md text-gray-800"
           placeholder="Proveedor o descripción"
         />
       </div>
 
       <div>
-        <label htmlFor="filter-from" className="mr-2 font-medium">Desde:</label>
+        <label htmlFor="filter-from" className="mr-2 font-medium text-gray-800">Desde:</label>
         <input
           id="filter-from"
           type="date"
           value={startDate}
           onChange={(e) => onStartDateChange(e.target.value)}
-          className="border border-gray-300 px-3 py-2 rounded-md"
+          className="border border-gray-300 px-3 py-2 rounded-md text-gray-800"
         />
       </div>
 
       <div>
-        <label htmlFor="filter-to" className="mr-2 font-medium">Hasta:</label>
+        <label htmlFor="filter-to" className="mr-2 font-medium text-gray-800">Hasta:</label>
         <input
           id="filter-to"
           type="date"
           value={endDate}
           onChange={(e) => onEndDateChange(e.target.value)}
-          className="border border-gray-300 px-3 py-2 rounded-md"
+          className="border border-gray-300 px-3 py-2 rounded-md text-gray-800"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- animate buttons on login and settings pages
- show toast message after saving settings
- dark text for filters so labels and inputs are legible

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b8306f5908321a604a7045420382a